### PR TITLE
Added usernames in export features. Added userID in chat files.

### DIFF
--- a/backend/src/main/kotlin/ch/ddis/speakeasy/chat/ChatMessage.kt
+++ b/backend/src/main/kotlin/ch/ddis/speakeasy/chat/ChatMessage.kt
@@ -1,10 +1,28 @@
 package ch.ddis.speakeasy.chat
 
 import ch.ddis.speakeasy.user.SessionId
+import ch.ddis.speakeasy.user.UserId
+import ch.ddis.speakeasy.user.UserManager
+import ch.ddis.speakeasy.util.UID
 import kotlinx.serialization.Serializable
 
+/**
+ * A chat message that can be sent in a chat room. A simple dataclass.
+ *
+ * @param message The message that is sent.
+ * @param authorUserId the UserID of the author.
+ * @param authorAlias The alias of the author of the message. As of now, this parameter could be removed and replaced by authorUserId.
+ * @param authorSessionId The session id of the author of the message.
+ * @param ordinal The ordinal of the message in the chat room.
+ * @param recipients The recipients of the message, but only their aliases.
+ * @param isRead Whether the message has been read.
+ * @param time The time the message was sent.
+ */
 data class ChatMessage(
     val message: String,
+    // NOTE FOR BACKWARD COMPATIBILITY: authorUserId is not present in earlier versions of Speakeasy.
+    // By default,
+    val authorUserId: UserId = UserId.INVALID,
     val authorAlias: String,
     val authorSessionId: SessionId,
     val ordinal: Int,
@@ -15,6 +33,23 @@ data class ChatMessage(
     ) : ChatItemContainer() {
 
     companion object {
+        /**
+         * Converts a list of ChatMessages to a list of ExportableMessages.
+         *
+         * @param chatMessages The list of ChatMessages to be converted.
+         */
+        fun toExportableMessages(chatMessages: List<ChatMessage>): List<ExportableMessage> {
+            return chatMessages.map {
+                val username =
+                // Two cases :
+                // 1. FOr backward compatibility, if the authorUserId is invalid, the username is "unknown", as authorUserID
+                // is not present in earlier versions of Speakeasy.
+                    // 2. authorUSerID can come from another speakeasy instance, and is therefore not registered in the current instance.
+                    if (UID.isInvalid(it.authorUserId)) ExportableMessage.UNKNOWN_USERNAME else UserManager.getUsernameFromId(it.authorUserId)
+                        ?: ExportableMessage.NOT_REGISTED_USERNAME
+                ExportableMessage(it.time, username, it.authorAlias, it.ordinal, it.message)
+            }
+        }
         fun toRestMessages(chatMessages: List<ChatMessage>):
             List<RestChatMessage> = chatMessages.map {
             RestChatMessage(it.time, it.authorAlias, it.ordinal, it.message, it.recipients, it.isRead)
@@ -28,6 +63,13 @@ data class ChatMessage(
 }
 
 @Serializable
+data class ExportableMessage(val timeStamp: Long, val authorUserName: String, val authorAlias: String, val ordinal: Int, val message: String) {
+    companion object {
+        const val NOT_REGISTED_USERNAME = "not_registered"
+        const val UNKNOWN_USERNAME = "unknown"
+    }
+}
+
 data class RestChatMessage(val timeStamp: Long, val authorAlias: String, val ordinal: Int, val message: String, val recipients: Set<String>, val isRead: Boolean)
 // TODO: what's the meaning of recipients and isRead? It seems isRead is useless, through
 data class SseChatMessage(val roomId:String, val timeStamp: Long, val authorAlias: String, val ordinal: Int,

--- a/backend/src/main/kotlin/ch/ddis/speakeasy/chat/ChatRoomManager.kt
+++ b/backend/src/main/kotlin/ch/ddis/speakeasy/chat/ChatRoomManager.kt
@@ -26,6 +26,7 @@ object ChatRoomManager {
 
     fun init() {
         // Recreates all chatrooms from the log files.
+        // This should defintely be encapsulated into a static method of Chatroom/logging room.
         this.basePath.walk().filter { it.isFile }.forEach { file ->
             val lines = file.readLines(Charsets.UTF_8)
             val users: MutableMap<UserId, String> = objectMapper.readValue(lines[6])
@@ -34,6 +35,7 @@ object ChatRoomManager {
             val assessedBy: MutableList<Assessor> = mutableListOf()
             var markAsNoFeedback: Boolean = false
 
+            // Parse .log files in order to populate the chatrooms with messages, reactions, etc.
             for (i in 8 until lines.size) {
                 when (val chatItem: ChatItemContainer = objectMapper.readValue(lines[i])) {
                     is ChatMessage -> messages.add(chatItem)
@@ -235,15 +237,15 @@ object ChatRoomManager {
     }
 
     /**
-     * Exports selected chatrooms to a list of SerializedChatRoom objects.
+     * Exports selected chatrooms to a list of ExportableChatrooms objects.
      *
      * @param chatRoomIds List of chatroom ids to export
      * @return List of SerializedChatRoom objects
      * @throws IllegalArgumentException if a chatroom id is not found
      */
-    fun exportSerializedChatrooms(chatRoomIds: List<ChatRoomId>): List<SerializedChatRoom> {
+    fun exportChatrooms(chatRoomIds: List<ChatRoomId>): List<ExportableChatRoom> {
         return chatRoomIds.map {
-            ChatRoom.exportSerialized(this.chatrooms.getOrElse( it) {
+            ChatRoom.export(this.chatrooms.getOrElse( it) {
                 throw IllegalArgumentException("Chatroom with id $it not found")
             })
         }

--- a/backend/src/main/kotlin/ch/ddis/speakeasy/util/UID.kt
+++ b/backend/src/main/kotlin/ch/ddis/speakeasy/util/UID.kt
@@ -1,11 +1,13 @@
 package ch.ddis.speakeasy.util
 
+import kotlinx.serialization.Serializable
 import org.jetbrains.exposed.dao.id.EntityID
 import java.util.*
 
 fun String.UID(): UID = UID(UUID.fromString(this))
 fun EntityID<UUID>.UID(): UID = UID(this.toString())
 
+@Serializable
 data class UID(val string: String) {
     constructor() : this(UUID.randomUUID().toString())
 
@@ -17,5 +19,21 @@ data class UID(val string: String) {
 
     fun toUUID(): UUID {
         return UUID.fromString(this.string)
+    }
+
+
+    companion object {
+        /**
+         * Invalid UID. Used e.g for default values.
+         */
+        val INVALID : UID = UID("00000000-0000-0000-0000-000000000000")
+
+        /**
+         * Checks if a given UID is invalid. An UID is invalid here if it is equal to the INVALID UID, this function does
+         * not check if the UID is a valid UUID in a programming sense.
+         */
+        fun isInvalid(uid: UID): Boolean {
+            return uid == INVALID
+        }
     }
 }


### PR DESCRIPTION
The goal of this PR was to introduce proper usernames in export files. As of now, only Aliases are saved in `ChatMessage` objects, and thus also in exported chats. 

This PR also adds a new field in `ChatMessages`, which is the `UserId` of the sender. Before that, only the alias was used to uniquely identified the message. 

To ensure backward compatibility, a default `UserId` is used when dealing with chat files from older versions.
 If the `UserId` is not found in the chat files, the username deduced from the alias stored in the `ChatRoom`. 